### PR TITLE
Fix command name

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ slotinfo get-state-id --state_name Maharashtra
 slotinfo get-district-id --state_id 21 --district_name Nanded
 
 3. Check available appointment slots district wise
-slotinfo district-wise --district_id 334 -date 10-05-2021
+slotinfo district-wise --district_id 334 --date 10-05-2021
 
 4. Check available appointment slots pincode wise
 slotinfo pincode-wise -pin 411015 --date 10-05-2021
@@ -54,7 +54,22 @@ slotinfo pincode-wise -pin 411015 --date 10-05-2021
 5. Run the script continously to check for available appointments after evey x(seconds) interval
 slotinfo continuously --district_id 363 --date 10-05-2021 --age_filter 18 --interval 2
 ```
+To get the help of any command use `--help` option with command name
+```
+slotinfo continuously --help
+Usage: slotinfo continuously [OPTIONS]
 
+Options:
+  -dId, --district_id TEXT   Provide district Id to check for appointments
+                             [required]
+
+  -d, --date TEXT            Date for which appointments are to be checked
+                             [required]
+
+  -af, --age_filter INTEGER  Filter only 18 plus or 45 plus appointments
+  -i, --interval INTEGER     Interval in seconds  [required]
+  --help                     Show this message and exit.
+```
 Notification will be send on the whatsapp
 
 <img width="350" alt="Screenshot 2021-05-09 at 10 01 03 PM" src="https://user-images.githubusercontent.com/52563354/117579869-927b1680-b112-11eb-9403-21438d53bc46.png">

--- a/slot_info/check_available_slots.py
+++ b/slot_info/check_available_slots.py
@@ -17,7 +17,7 @@ def main():
     pass
 
 
-@main.command()
+@main.command(name="pincode-wise")
 @click.option("-pin", "--pin_code",
               type=str,
               required=True,
@@ -82,7 +82,7 @@ def check_district_wise_slots(district_id, date, age_filter):
         raise ValueError("Possible values for age_filter is 18 or 45")
 
 
-@main.command()
+@main.command(name="district-wise")
 @click.option("-dId", "--district_id",
               type=str,
               required=True,
@@ -124,7 +124,7 @@ def print_error_message(http_error):
     print(error_message)
 
 
-@main.command()
+@main.command(name="get-state-id")
 @click.option("-sn", "--state_name",
               type=str,
               required=True,
@@ -154,7 +154,7 @@ def get_state_id(state_name):
         print_error_message(e)
 
 
-@main.command()
+@main.command(name="get-district-id")
 @click.option("-sId", "--state_id",
               type=str,
               required=True,


### PR DESCRIPTION
Observed that on python 3.6 the command name includes `_` in it, to avoid confusion, explicitly setting the name