### PR TITLE
Filter by Dose Number

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,28 +83,28 @@ slotinfo get-state-id --state_name Maharashtra
 slotinfo get-district-id --state_id 21 --district_name Pune
 
 3. Check available appointment slots district wise
-slotinfo district-wise --district_id 334 --date 10-05-2021 --age_filter 18 --notify_on whatsapp --vaccine_type covishield --vaccine_type covaxin
+slotinfo district-wise --district_id 334 --date 10-05-2021 --age_filter 18 --notify_on whatsapp --vaccine_type covishield --vaccine_type covaxin --dose_number 1
 
 4. Check available appointment slots district wise for next 7 days
-slotinfo district-wise-next7days --district_id 334 --date 10-05-2021 --age_filter 18 --notify_on whatsapp --vaccine_type covishield --vaccine_type covaxin
+slotinfo district-wise-next7days --district_id 334 --date 10-05-2021 --age_filter 18 --notify_on whatsapp --vaccine_type covishield --vaccine_type covaxin --dose_number 2
 
 5. Check available appointment slots pincode wise
-slotinfo pincode-wise-next7days -pin 411015 --date 10-05-2021 --age_filter 45 --notify_on telegram --vaccine_type covishield --vaccine_type covaxin
+slotinfo pincode-wise-next7days -pin 411015 --date 10-05-2021 --age_filter 45 --notify_on telegram --vaccine_type covishield --vaccine_type covaxin --dose_number 1
 
 6. Check available appointment slots pincode wise
-slotinfo pincode-wise -pin 411015 --date 10-05-2021 --age_filter 45 --notify_on telegram --vaccine_type covishield --vaccine_type covaxin
+slotinfo pincode-wise -pin 411015 --date 10-05-2021 --age_filter 45 --notify_on telegram --vaccine_type covishield --vaccine_type covaxin --dose_number 1
 
 7. Run the cmd continously to check for available appointments in a district after evey x(seconds) interval
-slotinfo continuously-for-district --district_id 363 --date 10-05-2021 --age_filter 18 --interval 2 --notify_on telegram --vaccine_type covishield --vaccine_type covaxin
+slotinfo continuously-for-district --district_id 363 --date 10-05-2021 --age_filter 18 --interval 2 --notify_on telegram --vaccine_type covishield --vaccine_type covaxin --dose_number 1
 
 8. Run the cmd continously to check for available appointments in a district for next 7 days after evey x(seconds) interval
-slotinfo continuously-for-district-next7days --district_id 363 --date 10-05-2021 --age_filter 18 --interval 2 --notify_on telegram --vaccine_type covishield --vaccine_type covaxin
+slotinfo continuously-for-district-next7days --district_id 363 --date 10-05-2021 --age_filter 18 --interval 2 --notify_on telegram --vaccine_type covishield --vaccine_type covaxin --dose_number 2
 
 9. Run the cmd continously to check for available appointments in pin code after evey x(seconds) interval
-slotinfo continuously-for-pincode --pin_code 41105 --date 10-05-2021 --age_filter 18 --interval 2 --notify_on whatsapp --vaccine_type covishield --vaccine_type covaxin
+slotinfo continuously-for-pincode --pin_code 41105 --date 10-05-2021 --age_filter 18 --interval 2 --notify_on whatsapp --vaccine_type covishield --vaccine_type covaxin --dose_number 1
 
 10. Run the cmd continously to check for available appointments in pin code for next 7 days after evey x(seconds) interval
-slotinfo continuously-for-pincode-next7days --pin_code 41105 --date 10-05-2021 --age_filter 18 --interval 2 --notify_on whatsapp --vaccine_type covishield --vaccine_type covaxin
+slotinfo continuously-for-pincode-next7days --pin_code 411015 --date 10-05-2021 --age_filter 18 --interval 2 --notify_on whatsapp --vaccine_type covishield --vaccine_type covaxin --dose_number 2
 ```
 
 To get the help of any command use `--help` option with command name

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-requests
-click
-twilio
-cacheout
-urllib3
+requests==2.25.1
+click==8.0.1
+twilio==6.59.0
+cacheout==0.13.1
+urllib3==1.26.4

--- a/slot_info/check_available_slots.py
+++ b/slot_info/check_available_slots.py
@@ -496,9 +496,9 @@ def check_district_wise_slots_next7days(district_id, date, age_filter, notify_on
 def is_slot_available(session, dose_number):
     is_available = False
     if session['available_capacity'] > 0:
-        if dose_number == 1 and session['available_capacity_dose1'] > 0:
-            is_available = True
-        if dose_number == 2 and session['available_capacity_dose2'] > 0:
+        if not dose_number or \
+                ("1" in dose_number and session['available_capacity_dose1'] > 0) or \
+                ("2" in dose_number and session['available_capacity_dose2'] > 0):
             is_available = True
     return is_available
 
@@ -516,7 +516,11 @@ def create_message_from_session(sessions, age_filter, notify_on, vaccine_types, 
                 message = message + "Name : " + str(session['name']) + "\n"
                 message = message + "Pincode: " + str(session['pincode']) + "\n"
                 message = message + "Vaccine Type: " + str(session['vaccine']) + "\n"
-                message = message + "Available Capacity: " + str(session['available_capacity']) + "\n"
+                message = message + "Total Available Capacity: " + str(session['available_capacity']) + "\n"
+                if "1" in dose_number and session['available_capacity_dose1'] > 0:
+                    message = message + "Available Capacity Dose1: " + str(session['available_capacity_dose1']) + "\n"
+                if "2" in dose_number and session['available_capacity_dose2'] > 0:
+                    message = message + "Available Capacity Dose2: " + str(session['available_capacity_dose2']) + "\n"
                 message = message + "Min Age: " + str(session['min_age_limit']) + "\n"
                 message = message + "Date: " + str(session['date']) + "\n"
                 send_message(message, notify_on)
@@ -549,4 +553,4 @@ def print_error_message(http_error):
 
 
 if __name__ == '__main__':
-    check_pincode_wise_slots_next7days('485446', '22-05-2021', 45, 'telegram', 'covishield', 1)
+    main()

--- a/slot_info/check_available_slots.py
+++ b/slot_info/check_available_slots.py
@@ -12,7 +12,7 @@ from cacheout import Cache
 from slot_info.constants import vaccine_types, dose_numbers
 
 # cache ttl is of 1 minute, this is to avoid sending multiple notifications
-cache = Cache(ttl=60)
+cache = Cache(ttl=600)
 session_requests = SessionRequest()
 
 

--- a/slot_info/check_available_slots.py
+++ b/slot_info/check_available_slots.py
@@ -9,7 +9,7 @@ from slot_info.session_requests import SessionRequest
 from slot_info.telegram import send_telegram_message
 from slot_info.whatsapp import send_whatsapp_message
 from cacheout import Cache
-from slot_info.constants import vaccine_types
+from slot_info.constants import vaccine_types, dose_numbers
 
 # cache ttl is of 1 minute, this is to avoid sending multiple notifications
 cache = Cache(ttl=60)
@@ -46,7 +46,13 @@ def main():
               required=False,
               multiple=True,
               default=[],
-              help="Vaccine_type for which appointments are to be checked")
+              help="Vaccine type for which appointments are to be checked")
+@click.option("-dn", "--dose_number",
+              type=click.Choice(dose_numbers),
+              required=False,
+              multiple=True,
+              default=[],
+              help="Dose number for which appointments are to be checked")
 def pincode_wise(pin_code, date, age_filter, notify_on, vaccine_type):
     """
     get pin code wise available slots on a specific date in a given pin.
@@ -78,7 +84,13 @@ def pincode_wise(pin_code, date, age_filter, notify_on, vaccine_type):
               required=False,
               multiple=True,
               default=[],
-              help="Vaccine_type for which appointments are to be checked")
+              help="Vaccine type for which appointments are to be checked")
+@click.option("-dn", "--dose_number",
+              type=click.Choice(dose_numbers),
+              required=False,
+              multiple=True,
+              default=[],
+              help="Dose number for which appointments are to be checked")
 def district_wise(district_id, date, age_filter, notify_on, vaccine_type):
     """
     get district wise available slots on a specific date in a given district.
@@ -170,7 +182,13 @@ def get_district_id(state_id, district_name):
               required=False,
               multiple=True,
               default=[],
-              help="Vaccine_type for which appointments are to be checked")
+              help="Vaccine type for which appointments are to be checked")
+@click.option("-dn", "--dose_number",
+              type=click.Choice(dose_numbers),
+              required=False,
+              multiple=True,
+              default=[],
+              help="Dose number for which appointments are to be checked")
 def continuously_for_district(district_id, date, age_filter, interval, notify_on, vaccine_type):
     """
     Continuously check for available slots in district for a specific date after every x interval seconds
@@ -209,7 +227,13 @@ def continuously_for_district(district_id, date, age_filter, interval, notify_on
               required=False,
               multiple=True,
               default=[],
-              help="Vaccine_type for which appointments are to be checked")
+              help="Vaccine type for which appointments are to be checked")
+@click.option("-dn", "--dose_number",
+              type=click.Choice(dose_numbers),
+              required=False,
+              multiple=True,
+              default=[],
+              help="Dose number for which appointments are to be checked")
 def continuously_for_district_next7days(district_id, date, age_filter, interval, notify_on, vaccine_type):
     """
     Continuously check for available slots in district for next 7 days after every x interval seconds
@@ -248,7 +272,13 @@ def continuously_for_district_next7days(district_id, date, age_filter, interval,
               required=False,
               multiple=True,
               default=[],
-              help="Vaccine_type for which appointments are to be checked")
+              help="Vaccine type for which appointments are to be checked")
+@click.option("-dn", "--dose_number",
+              type=click.Choice(dose_numbers),
+              required=False,
+              multiple=True,
+              default=[],
+              help="Dose number for which appointments are to be checked")
 def continuously_for_pincode(pin_code, date, age_filter, interval, notify_on, vaccine_type):
     """
     Continuously check for available slots in pin code for a specific date after every x interval seconds
@@ -288,6 +318,12 @@ def continuously_for_pincode(pin_code, date, age_filter, interval, notify_on, va
               multiple=True,
               default=[],
               help="Vaccine_type for which appointments are to be checked")
+@click.option("-dn", "--dose_number",
+              type=click.Choice(dose_numbers),
+              required=False,
+              multiple=True,
+              default=[],
+              help="Dose number for which appointments are to be checked")
 def continuously_for_pincode_next7days(pin_code, date, age_filter, interval, notify_on, vaccine_type):
     """
     Continuously check for available slots in pin code for next 7 days after every x interval seconds
@@ -322,7 +358,13 @@ def continuously_for_pincode_next7days(pin_code, date, age_filter, interval, not
               required=False,
               multiple=True,
               default=[],
-              help="Vaccine_type for which appointments are to be checked")
+              help="Vaccine type for which appointments are to be checked")
+@click.option("-dn", "--dose_number",
+              type=click.Choice(dose_numbers),
+              required=False,
+              multiple=True,
+              default=[],
+              help="Dose number for which appointments are to be checked")
 def pincode_wise_next7days(pin_code, date, age_filter, notify_on, vaccine_type):
     """
     Check for available slots in pin code for next 7 days from the date provided
@@ -354,7 +396,13 @@ def pincode_wise_next7days(pin_code, date, age_filter, notify_on, vaccine_type):
               required=False,
               multiple=True,
               default=[],
-              help="Vaccine_type for which appointments are to be checked")
+              help="Vaccine type for which appointments are to be checked")
+@click.option("-dn", "--dose_number",
+              type=click.Choice(dose_numbers),
+              required=False,
+              multiple=True,
+              default=[],
+              help="Dose number for which appointments are to be checked")
 def district_wise_next7days(district_id, date, age_filter, notify_on, vaccine_type):
     """
     Check for available slots in district for next 7 days from the date provided
@@ -364,7 +412,7 @@ def district_wise_next7days(district_id, date, age_filter, notify_on, vaccine_ty
     check_district_wise_slots_next7days(district_id, date, age_filter, notify_on, vaccine_type)
 
 
-def check_pincode_wise_slots(pin_code, date, age_filter, notify_on, vaccine_types):
+def check_pincode_wise_slots(pin_code, date, age_filter, notify_on, vaccine_types, dose_number):
     validate_inputs(date, age_filter)
     url = BASE_API + find_by_pin
     params = {
@@ -374,14 +422,14 @@ def check_pincode_wise_slots(pin_code, date, age_filter, notify_on, vaccine_type
     try:
         response_data = session_requests.get(url=url, params=params)
         if len(response_data['sessions']) > 0:
-            create_message_from_session(response_data['sessions'], age_filter, notify_on, vaccine_types)
+            create_message_from_session(response_data['sessions'], age_filter, notify_on, vaccine_types, dose_number)
         else:
             print("No slots are available for pincode: ", pin_code)
     except requests.HTTPError as http_error:
         print_error_message(http_error)
 
 
-def check_pincode_wise_slots_next7days(pin_code, date, age_filter, notify_on, vaccine_types):
+def check_pincode_wise_slots_next7days(pin_code, date, age_filter, notify_on, vaccine_types, dose_number):
     validate_inputs(date, age_filter)
     url = BASE_API + calendar_by_pin
 
@@ -397,14 +445,14 @@ def check_pincode_wise_slots_next7days(pin_code, date, age_filter, notify_on, va
                     session['pincode'] = center['pincode']
                     session['name'] = center['name']
                     sessions = [session]
-                    create_message_from_session(sessions, age_filter, notify_on, vaccine_types)
+                    create_message_from_session(sessions, age_filter, notify_on, vaccine_types, dose_number)
         else:
             print("There are no centers available for this pin code")
     except requests.HTTPError as http_error:
         print_error_message(http_error)
 
 
-def check_district_wise_slots(district_id, date, age_filter, notify_on, vaccine_types):
+def check_district_wise_slots(district_id, date, age_filter, notify_on, vaccine_types, dose_number):
     validate_inputs(date, age_filter)
     url = BASE_API + find_by_district
     params = {
@@ -415,14 +463,14 @@ def check_district_wise_slots(district_id, date, age_filter, notify_on, vaccine_
     try:
         response_data = session_requests.get(url=url, params=params)
         if len(response_data['sessions']) > 0:
-            create_message_from_session(response_data['sessions'], age_filter, notify_on, vaccine_types)
+            create_message_from_session(response_data['sessions'], age_filter, notify_on, vaccine_types, dose_number)
         else:
             print("No slots are available for district: ", district_id)
     except requests.HTTPError as http_error:
         print_error_message(http_error)
 
 
-def check_district_wise_slots_next7days(district_id, date, age_filter, notify_on, vaccine_types):
+def check_district_wise_slots_next7days(district_id, date, age_filter, notify_on, vaccine_types, dose_number):
     validate_inputs(date, age_filter)
     url = BASE_API + calendar_by_district
     params = {
@@ -438,17 +486,29 @@ def check_district_wise_slots_next7days(district_id, date, age_filter, notify_on
                     session['pincode'] = center['pincode']
                     session['name'] = center['name']
                     sessions = [session]
-                    create_message_from_session(sessions, age_filter, notify_on, vaccine_types)
+                    create_message_from_session(sessions, age_filter, notify_on, vaccine_types, dose_number)
         else:
             print("There are no centers available for this district")
     except requests.HTTPError as http_error:
         print_error_message(http_error)
 
 
-def create_message_from_session(sessions, age_filter, notify_on, vaccine_types):
+def is_slot_available(session, dose_number):
+    is_available = False
+    if session['available_capacity'] > 0:
+        if dose_number == 1 and session['available_capacity_dose1'] > 0:
+            is_available = True
+        if dose_number == 2 and session['available_capacity_dose2'] > 0:
+            is_available = True
+    return is_available
+
+
+def create_message_from_session(sessions, age_filter, notify_on, vaccine_types, dose_number):
     message = "Following Centers are available \n\n"
     for session in sessions:
-        if session['available_capacity'] > 0 and session['min_age_limit'] == age_filter and (not vaccine_types or session['vaccine'].lower() in vaccine_types):
+        if is_slot_available(session, dose_number) and \
+                session['min_age_limit'] == age_filter and \
+                (not vaccine_types or session['vaccine'].lower() in vaccine_types):
             print("Name: " + str(session['name']) + ", PinCode: " + str(session['pincode']) + ", Available: " + str(
                 session['available_capacity']) + ", Date :" + str(session['date']))
             if cache.get(str(session['pincode']) + session['name'] + str(session['date'])) is None:

--- a/slot_info/check_available_slots.py
+++ b/slot_info/check_available_slots.py
@@ -53,13 +53,13 @@ def main():
               multiple=True,
               default=[],
               help="Dose number for which appointments are to be checked")
-def pincode_wise(pin_code, date, age_filter, notify_on, vaccine_type):
+def pincode_wise(pin_code, date, age_filter, notify_on, vaccine_type, dose_number):
     """
     get pin code wise available slots on a specific date in a given pin.
     """
     print("Checking for available slots in pin code " + str(pin_code) + ", for date " + str(date) +
           ",for min_age: " + str(age_filter))
-    check_pincode_wise_slots(pin_code, date, age_filter, notify_on, vaccine_type)
+    check_pincode_wise_slots(pin_code, date, age_filter, notify_on, vaccine_type, dose_number)
 
 
 @main.command(name="district-wise")
@@ -91,13 +91,13 @@ def pincode_wise(pin_code, date, age_filter, notify_on, vaccine_type):
               multiple=True,
               default=[],
               help="Dose number for which appointments are to be checked")
-def district_wise(district_id, date, age_filter, notify_on, vaccine_type):
+def district_wise(district_id, date, age_filter, notify_on, vaccine_type, dose_number):
     """
     get district wise available slots on a specific date in a given district.
     """
     print("Checking for available slots in district " + str(district_id) + ", for date " + str(
         date) + ",for min_age: " + str(age_filter))
-    check_district_wise_slots(district_id, date, age_filter, notify_on, vaccine_type)
+    check_district_wise_slots(district_id, date, age_filter, notify_on, vaccine_type, dose_number)
 
 
 @main.command(name="get-state-id")
@@ -189,7 +189,7 @@ def get_district_id(state_id, district_name):
               multiple=True,
               default=[],
               help="Dose number for which appointments are to be checked")
-def continuously_for_district(district_id, date, age_filter, interval, notify_on, vaccine_type):
+def continuously_for_district(district_id, date, age_filter, interval, notify_on, vaccine_type, dose_number):
     """
     Continuously check for available slots in district for a specific date after every x interval seconds
     and notify on whatsapp/telegram
@@ -197,7 +197,7 @@ def continuously_for_district(district_id, date, age_filter, interval, notify_on
     print("Checking for available slots in district " + str(district_id) + ", for date " + str(
         date) + ",for min_age: " + str(age_filter))
     while True:
-        check_district_wise_slots(district_id, date, age_filter, notify_on, vaccine_type)
+        check_district_wise_slots(district_id, date, age_filter, notify_on, vaccine_type, dose_number)
         time.sleep(interval)
 
 
@@ -234,7 +234,7 @@ def continuously_for_district(district_id, date, age_filter, interval, notify_on
               multiple=True,
               default=[],
               help="Dose number for which appointments are to be checked")
-def continuously_for_district_next7days(district_id, date, age_filter, interval, notify_on, vaccine_type):
+def continuously_for_district_next7days(district_id, date, age_filter, interval, notify_on, vaccine_type, dose_number):
     """
     Continuously check for available slots in district for next 7 days after every x interval seconds
     and notify on whatsapp/telegram
@@ -242,7 +242,7 @@ def continuously_for_district_next7days(district_id, date, age_filter, interval,
     print("Checking for available slots in district " + str(district_id) + ", for next 7 days starting from date:  "
           + str(date) + ",for min_age: " + str(age_filter))
     while True:
-        check_district_wise_slots_next7days(district_id, date, age_filter, notify_on, vaccine_type)
+        check_district_wise_slots_next7days(district_id, date, age_filter, notify_on, vaccine_type, dose_number)
         time.sleep(interval)
 
 
@@ -279,7 +279,7 @@ def continuously_for_district_next7days(district_id, date, age_filter, interval,
               multiple=True,
               default=[],
               help="Dose number for which appointments are to be checked")
-def continuously_for_pincode(pin_code, date, age_filter, interval, notify_on, vaccine_type):
+def continuously_for_pincode(pin_code, date, age_filter, interval, notify_on, vaccine_type, dose_number):
     """
     Continuously check for available slots in pin code for a specific date after every x interval seconds
     and notify on whatsapp/telegram
@@ -287,7 +287,7 @@ def continuously_for_pincode(pin_code, date, age_filter, interval, notify_on, va
     print("Checking for available slots in pin code " + str(pin_code) + ", for date " + str(date) +
           ",for min_age: " + str(age_filter))
     while True:
-        check_pincode_wise_slots(pin_code, date, age_filter, notify_on, vaccine_type)
+        check_pincode_wise_slots(pin_code, date, age_filter, notify_on, vaccine_type, dose_number)
         time.sleep(interval)
 
 
@@ -324,7 +324,7 @@ def continuously_for_pincode(pin_code, date, age_filter, interval, notify_on, va
               multiple=True,
               default=[],
               help="Dose number for which appointments are to be checked")
-def continuously_for_pincode_next7days(pin_code, date, age_filter, interval, notify_on, vaccine_type):
+def continuously_for_pincode_next7days(pin_code, date, age_filter, interval, notify_on, vaccine_type, dose_number):
     """
     Continuously check for available slots in pin code for next 7 days after every x interval seconds
     and notify on whatsapp/telegram
@@ -332,7 +332,7 @@ def continuously_for_pincode_next7days(pin_code, date, age_filter, interval, not
     print("Checking for available slots in pin code " + str(pin_code) + ", for next 7 days starting from date " + str(
         date) + ",for min_age: " + str(age_filter))
     while True:
-        check_pincode_wise_slots_next7days(pin_code, date, age_filter, notify_on, vaccine_type)
+        check_pincode_wise_slots_next7days(pin_code, date, age_filter, notify_on, vaccine_type, dose_number)
         time.sleep(interval)
 
 
@@ -365,13 +365,13 @@ def continuously_for_pincode_next7days(pin_code, date, age_filter, interval, not
               multiple=True,
               default=[],
               help="Dose number for which appointments are to be checked")
-def pincode_wise_next7days(pin_code, date, age_filter, notify_on, vaccine_type):
+def pincode_wise_next7days(pin_code, date, age_filter, notify_on, vaccine_type, dose_number):
     """
     Check for available slots in pin code for next 7 days from the date provided
     """
     print("Checking for available slots in pin code " + str(pin_code) + ", for next 7 days starting from date "
           + str(date) + ",for min_age: " + str(age_filter))
-    check_pincode_wise_slots_next7days(pin_code, date, age_filter, notify_on, vaccine_type)
+    check_pincode_wise_slots_next7days(pin_code, date, age_filter, notify_on, vaccine_type, dose_number)
 
 
 @main.command(name="district-wise-next7days")
@@ -403,13 +403,13 @@ def pincode_wise_next7days(pin_code, date, age_filter, notify_on, vaccine_type):
               multiple=True,
               default=[],
               help="Dose number for which appointments are to be checked")
-def district_wise_next7days(district_id, date, age_filter, notify_on, vaccine_type):
+def district_wise_next7days(district_id, date, age_filter, notify_on, vaccine_type, dose_number):
     """
     Check for available slots in district for next 7 days from the date provided
     """
     print("Checking for available slots in district " + str(district_id) + ", for next 7 days starting from date "
           + str(date) + ",for min_age: " + str(age_filter))
-    check_district_wise_slots_next7days(district_id, date, age_filter, notify_on, vaccine_type)
+    check_district_wise_slots_next7days(district_id, date, age_filter, notify_on, vaccine_type, dose_number)
 
 
 def check_pincode_wise_slots(pin_code, date, age_filter, notify_on, vaccine_types, dose_number):
@@ -549,4 +549,4 @@ def print_error_message(http_error):
 
 
 if __name__ == '__main__':
-    main()
+    check_pincode_wise_slots_next7days('485446', '22-05-2021', 45, 'telegram', 'covishield', 1)

--- a/slot_info/constants.py
+++ b/slot_info/constants.py
@@ -1,2 +1,2 @@
 vaccine_types = ["covishield", "covaxin"]
-dose_numbers = [1, 2]
+dose_numbers = ["1", "2"]

--- a/slot_info/constants.py
+++ b/slot_info/constants.py
@@ -1,1 +1,2 @@
 vaccine_types = ["covishield", "covaxin"]
+dose_numbers = [1, 2]


### PR DESCRIPTION
### Why are we doing this change ?

- This change is to support the user to get the slots availability based on the dose number provided
- Recently CoWin has made a change to provide available slots based on Dose number. With the current release user might get notified for available slots but the same will not be shown on UI as per the Dose number, see issue https://github.com/veenaypatil/Vaccine-Slot-Info/issues/11

---
### Testing

Tested with following cmds
```
slotinfo continuously-for-pincode-next7days --pin_code 485001 --date 22-05-2021 --age_filter 45 --interval 3 --notify_on telegram -dn 2

slotinfo continuously-for-district-next7days --district_id 333 --date 22-05-2021 --age_filter 45 --interval 3 --notify_on telegram --vaccine_type covishield -dn 1
```
<img width="650" alt="Screenshot 2021-05-23 at 6 37 25 PM" src="https://user-images.githubusercontent.com/52563354/119261654-00850a80-bbf6-11eb-98d4-f1f851868599.png">
